### PR TITLE
Better implementation of createResPath, apply hashcode.

### DIFF
--- a/src/lib/api/mooltipage.ts
+++ b/src/lib/api/mooltipage.ts
@@ -1,7 +1,7 @@
 import Path
     from 'path';
 
-import {StandardPipeline} from '../pipeline/standardPipeline';
+import {StandardPipeline, hashMD5} from '../pipeline/standardPipeline';
 import * as FsUtils
     from '../fs/fsUtils';
 import {

--- a/src/lib/api/mooltipage.ts
+++ b/src/lib/api/mooltipage.ts
@@ -168,11 +168,6 @@ export class NodePipelineInterface implements PipelineInterface {
     readonly destinationPath: string;
 
     /**
-     * Next available generated resource ID
-     */
-    private nextResIndex = 0;
-
-    /**
      * Creates a new NodePipelineInterface.
      * If either argument is not set, then it will default to the current working directory.
      *
@@ -198,7 +193,7 @@ export class NodePipelineInterface implements PipelineInterface {
 
     // sourceResPath is available as last parameter, if needed
     createResource(type: MimeType, contents: string): string {
-        const resPath = this.createResPath(type);
+        const resPath = this.createResPath(type, contents);
 
         this.writeResource(type, resPath, contents);
 
@@ -229,12 +224,11 @@ export class NodePipelineInterface implements PipelineInterface {
      * @param type MIME type of the resource to create
      * @returns returns a unique resource path that is acceptable for the specified MIME type
      */
-    createResPath(type: MimeType): string {
-        const index = this.nextResIndex;
-        this.nextResIndex++;
+    createResPath(type: MimeType, contents: string): string {
+        const contentHash = FsUtils.hashCode(contents);
 
         const extension = getResourceTypeExtension(type);
-        const fileName = `${ index }.${ extension }`;
+        const fileName = `${ contentHash }.${ extension }`;
 
         return Path.join('resources', fileName);
     }

--- a/src/lib/api/mooltipage.ts
+++ b/src/lib/api/mooltipage.ts
@@ -225,7 +225,7 @@ export class NodePipelineInterface implements PipelineInterface {
      * @returns returns a unique resource path that is acceptable for the specified MIME type
      */
     createResPath(type: MimeType, contents: string): string {
-        const contentHash = FsUtils.hashCode(contents);
+        const contentHash = hashMD5(contents);
 
         const extension = getResourceTypeExtension(type);
         const fileName = `${ contentHash }.${ extension }`;

--- a/src/lib/fs/fsUtils.ts
+++ b/src/lib/fs/fsUtils.ts
@@ -108,4 +108,4 @@ function expandPagePath(pagePath: string, basePath: string, outPaths: string[]):
     }
 
     // other file types (such as links) are currently skipped
-}
+} 

--- a/src/lib/fs/fsUtils.ts
+++ b/src/lib/fs/fsUtils.ts
@@ -109,21 +109,3 @@ function expandPagePath(pagePath: string, basePath: string, outPaths: string[]):
 
     // other file types (such as links) are currently skipped
 }
-
-/**
- * Takes string and convert it into 32 bit hash
- *
- * @param content string value, a file contains
- * @returns hash string
- */
-export function hashCode(content: string): string{
-    let hash = 0;
-    if (content.length === 0) return hash.toString();
-    for (let i = 0; i < content.length; i++){
-        const char = content.charCodeAt(i);
-        hash = ((hash << 5) - hash) + char;
-        hash = hash & hash;
-    }
-
-    return hash.toString();
-}

--- a/src/lib/fs/fsUtils.ts
+++ b/src/lib/fs/fsUtils.ts
@@ -109,3 +109,21 @@ function expandPagePath(pagePath: string, basePath: string, outPaths: string[]):
 
     // other file types (such as links) are currently skipped
 }
+
+/**
+ * Takes string and convert it into 32 bit hash
+ *
+ * @param content string value, a file contains
+ * @returns hash string
+ */
+export function hashCode(content: string): string{
+    let hash = 0;
+    if (content.length === 0) return hash.toString();
+    for (let i = 0; i < content.length; i++){
+        const char = content.charCodeAt(i);
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash;
+    }
+
+    return hash.toString();
+}

--- a/src/lib/pipeline/standardPipeline.ts
+++ b/src/lib/pipeline/standardPipeline.ts
@@ -187,7 +187,7 @@ export class StandardPipeline implements Pipeline {
 
     private createLinkableResource(type: MimeType, contents: string, sourceResPath: string, rootResPath: string): string {
         // hash contents
-        const contentsHash = this.fastHashContent(contents);
+        const contentsHash = hashMD5(contents);
 
         // get from cache, if present
         if (this.cache.hasCreatedResource(contentsHash)) {
@@ -244,28 +244,6 @@ export class StandardPipeline implements Pipeline {
     reset(): void {
         // clear cache to reset state
         this.cache.clear();
-    }
-
-    /**
-     * Create a NON-CRYPTOGRAPHIC (INSECURE) hash of some pipeline content.
-     * Hash algorithm should be strong enough to use for caching, but does not need to be cryptographically secure.
-     * This may be called many times by the pipeline, so the algorithm used should be reasonably fast as well.
-     * 
-     * Standard implementation uses MD5 as provided by the Node.JS Crypto module.
-     * Override to change implementation
-     * 
-     * @param content Content to hash. Should be a UTF-8 string.
-     * @returns Returns a hash of content as a Base64 string
-     */
-    protected fastHashContent(content: string): string {
-        // create hash instance
-        const md5 = crypto.createHash('md5');
-        
-        // load the content
-        md5.update(content, 'utf8');
-
-        // calculate the hash
-        return md5.digest('base64');
     }
 
     private getOrParseFragment(resPath: string): Fragment {
@@ -330,8 +308,12 @@ export class StandardPipeline implements Pipeline {
 }
 
 /**
- * Calculates the MD5 hash of a UTF8 string using Node.JS crypto APIs.
- * MD5 is an INSECURE hash so this should ONLY be used for non-security-sensitive tasks like caching.
+ * Create a NON-CRYPTOGRAPHIC (INSECURE) hash of some pipeline content.
+ * Hash algorithm should be strong enough to use for caching, but does not need to be cryptographically secure.
+ * This may be called many times by the pipeline, so the algorithm used should be reasonably fast as well.
+ * 
+ * Standard implementation uses MD5 as provided by the Node.JS Crypto module.
+ * Override to change implementation
  * 
  * @param content Content to hash. Should be a UTF-8 string.
  * @returns Returns a hash of content as a Base64 string

--- a/src/test/unit/mooltipageApiTests.ts
+++ b/src/test/unit/mooltipageApiTests.ts
@@ -65,18 +65,18 @@ test('NodePipelineInterface.resolveDestinationResource() resolves relative to de
 test('NodePipelineInterface.createResPath() generates unique resource paths', t => {
     const pi = new NodePipelineInterface();
     const paths = new Set<string>();
-    paths.add(pi.createResPath(MimeType.TEXT));
-    paths.add(pi.createResPath(MimeType.TEXT));
-    paths.add(pi.createResPath(MimeType.CSS));
-    paths.add(pi.createResPath(MimeType.CSS));
-    paths.add(pi.createResPath(MimeType.JAVASCRIPT));
-    paths.add(pi.createResPath(MimeType.JAVASCRIPT));
-    t.is(paths.size, 6);
+    paths.add(pi.createResPath(MimeType.TEXT, 'test'));
+    paths.add(pi.createResPath(MimeType.TEXT, 'test'));
+    paths.add(pi.createResPath(MimeType.CSS, 'test'));
+    paths.add(pi.createResPath(MimeType.CSS, 'test'));
+    paths.add(pi.createResPath(MimeType.JAVASCRIPT, 'test'));
+    paths.add(pi.createResPath(MimeType.JAVASCRIPT, 'test'));
+    t.is(paths.size, 3);
 });
 test('NodePipelineInterface.createResPath() attaches correct file extension', t => {
     const pi = new NodePipelineInterface();
     for (const mime of [MimeType.HTML, MimeType.CSS, MimeType.JAVASCRIPT, MimeType.JSON, MimeType.TEXT, 'unknown' as MimeType]) {
-        t.true(pi.createResPath(mime).endsWith(getResourceTypeExtension(mime)));
+        t.true(pi.createResPath(mime, 'test').endsWith(getResourceTypeExtension(mime)));
     }
 });
 test('NodePipelineInterface.getResource() reads relative to source path', t => {


### PR DESCRIPTION
This addresses the issue #53 
Previously, app is using index for creating res path, this implementation takes contents as argument and convert it to 32-bit hash and name the res path.