### PR TITLE
Expand patterns for lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     }
   },
   "lint-staged": {
-    "./**/*.ts": [
+    "./**/*.{ts,js}": [
       "npm run lint"
     ]
   }


### PR DESCRIPTION
fixes #65 
`.js` is added in `lint-staged` pattern